### PR TITLE
Update to run with Ubuntu 20.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,27 @@
-FROM ubuntu:14.04
+FROM ubuntu:20.04
 RUN apt-get update
 
-RUN apt-get install -y wget
-RUN for deb in deb deb-src; do echo "$deb http://build.openmodelica.org/apt `lsb_release -cs` stable"; done | sudo tee /etc/apt/sources.list.d/openmodelica.list
-RUN wget -q http://build.openmodelica.org/apt/openmodelica.asc -O- | sudo apt-key add - 
+RUN DEBIAN_FRONTEND=noninteractive apt install -y gnupg lsb-release wget
+RUN for deb in deb deb-src; do echo "$deb http://build.openmodelica.org/apt `lsb_release -cs` stable"; done | tee /etc/apt/sources.list.d/openmodelica.list
+RUN wget -q http://build.openmodelica.org/apt/openmodelica.asc -O- | apt-key add -
 
 # Update index (again)
 RUN apt-get update
 
 # Install minimal OpenModelica Components
-RUN apt-get install -y omc omlib-modelica-3.2.2
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y omc omlib-modelica-3.2.2
 
 # Install Python components
-RUN apt-get install -y python-pip python-dev build-essential 
-RUN apt-get install -y git
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-dev build-essential
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git
 
 # Install Jupyter notebook, always upgrade pip
-RUN pip install --upgrade pip
-RUN pip install jupyter
+RUN pip3 install --upgrade pip
+RUN pip3 install jupyter
 
 # Install OMPython and jupyter-openmodelica kernel
-RUN pip install -U git+git://github.com/OpenModelica/OMPython.git
-RUN pip install -U git+git://github.com/OpenModelica/jupyter-openmodelica.git
+RUN pip3 install -U git+git://github.com/OpenModelica/OMPython.git
+RUN pip3 install -U git+git://github.com/OpenModelica/jupyter-openmodelica.git
 
 # Create a user profile "openmodelicausers" inside the docker container as we should run the docker container as non-root users
 RUN useradd -m -s /bin/bash openmodelicausers
@@ -39,7 +39,3 @@ WORKDIR $HOME
 EXPOSE 8888
 
 CMD ["jupyter", "notebook", "--port=8888", "--ip=0.0.0.0", "--allow-root"]
-
-
-
-


### PR DESCRIPTION
Ubuntu 14.04 is too old, and so the packages won't compile with its version of python.  Updated to the most stable Ubuntu version.